### PR TITLE
check api keys exporting

### DIFF
--- a/lib/yabeda/datadog.rb
+++ b/lib/yabeda/datadog.rb
@@ -3,6 +3,7 @@
 require "yabeda"
 require "yabeda/datadog/adapter"
 require "yabeda/datadog/version"
+require "yabeda/datadog/exceptions"
 
 module Yabeda
   # = Namespace for DataDog adapter
@@ -12,6 +13,7 @@ module Yabeda
 
     # TODO: consider to change too manual
     def self.start
+      raise ApiKeyError, 'DataDog API key or application key not set to envoirmental variable' if ENV['DATADOG_API_KEY'].nil? || ENV['DATADOG_APP_KEY'].nil?
       adapter = Yabeda::Datadog::Adapter.new
       Yabeda.register_adapter(:datadog, adapter)
       adapter

--- a/lib/yabeda/datadog.rb
+++ b/lib/yabeda/datadog.rb
@@ -13,7 +13,8 @@ module Yabeda
 
     # TODO: consider to change too manual
     def self.start
-      raise ApiKeyError, 'DataDog API key or application key not set to envoirmental variable' if ENV['DATADOG_API_KEY'].nil? || ENV['DATADOG_APP_KEY'].nil?
+      raise ApiKeyError if ENV['DATADOG_API_KEY'].nil?
+      raise AppKeyError if ENV['DATADOG_APP_KEY'].nil?
       adapter = Yabeda::Datadog::Adapter.new
       Yabeda.register_adapter(:datadog, adapter)
       adapter

--- a/lib/yabeda/datadog/exceptions.rb
+++ b/lib/yabeda/datadog/exceptions.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 	
 module Yabeda
-  module DataDog
-    class ApiKeyError < StandardError; end
+  module Datadog
+    class ApiKeyError < StandardError
+      def initialize(msg="DataDog API key doesn't set")
+        super
+      end
+    end
+
+    class AppKeyError < StandardError
+      def initialize(msg="DataDog application key doesn't set")
+        super
+      end
+    end
   end
 end

--- a/lib/yabeda/datadog/exceptions.rb
+++ b/lib/yabeda/datadog/exceptions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+	
+module Yabeda
+  module DataDog
+    class ApiKeyError < StandardError; end
+  end
+end


### PR DESCRIPTION
It's reasonable to check api keys in adapter register because it prevents exceptions on workers runtime.