### PR TITLE
Clarify error message about failed metric metadata update

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,13 @@ Yabeda::Datadog.start_exporter(collect_interval: TEN_SECONDS)
 
 ### Limitations
 
-On the first run of your application no metrics metadata will be updated. This is happening because metrics have not yet been collected, thus not been created, and there is nothing to update.
+On the first run of your application you will see such error messages in your logs:
+
+    ERROR -- yabeda_datadog: metric registration failed for yourapp.some_metric: metric_name not found
+
+This is happening because metrics have not yet been collected and pushed to the DataDog (it may take up to the minute). So update metric metadata request to DataDog is failing.
+
+This error will disappear on next run when all metrics' data reach DataDog and DataDog will be aware of it.
 
 ### Example
 

--- a/lib/yabeda/datadog/worker/register.rb
+++ b/lib/yabeda/datadog/worker/register.rb
@@ -14,7 +14,7 @@ module Yabeda
               metric.update(dogapi)
             end
           rescue StandardError => err
-            Logging.instance.error("metric registration failed: #{err.message}")
+            Logging.instance.error("metric registration failed for #{metric.name}: #{err.message}")
           end
         end
       end


### PR DESCRIPTION
Now it is hard to say which metric is unable to be registered and README does not explain why it happens accessible enough.